### PR TITLE
REQ-19630 improve performance updating Richtext component

### DIFF
--- a/src/Prismic/Dom/RichText.php
+++ b/src/Prismic/Dom/RichText.php
@@ -32,7 +32,7 @@ class RichText
             }
         }
 
-        return $result;
+        return trim($result);
     }
 
     /**
@@ -151,7 +151,7 @@ class RichText
     private static function insertSpans($text, array $spans, $linkResolver = null, $htmlSerializer = null)
     {
         if (empty($spans)) {
-            return htmlentities($text, null, 'UTF-8');
+            return htmlentities($text, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, 'UTF-8');
         }
 
         $tagsStart = [];
@@ -213,14 +213,14 @@ class RichText
                 $c = mb_substr($text, $pos, 1, 'UTF-8');
                 if (count($stack) == 0) {
                     // Top-level text
-                    $html .= htmlentities($c, null, 'UTF-8');
+                    $html .= htmlentities($c, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, 'UTF-8');
                 } else {
                     // Inner text of a span
                     $last_idx = count($stack) - 1;
                     $last = $stack[$last_idx];
                     $stack[$last_idx] = [
                         'span' => $last['span'],
-                        'text' => $last['text'] . htmlentities($c, null, 'UTF-8')
+                        'text' => $last['text'] . htmlentities($c, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, 'UTF-8')
                     ];
                 }
             }
@@ -277,9 +277,16 @@ class RichText
             case 'o-list-item':
                 return nl2br('<li' . $classCode . '>' . $content . '</li>');
             case 'image':
+                $img = '<img src="' . $element->url . '" alt="' . htmlentities($element->alt) . '">';
+
+                $link = property_exists($element, 'linkTo') ? Link::asUrl($element->linkTo, $linkResolver) : null;
+
+                $target     = property_exists($element, 'linkTo') ? ($element->linkTo->target ?? null) : null;
+                $targetCode = $target ? ' target="' . htmlentities($target) . '"' : '';
+
                 return (
                     '<p class="block-img' . (isset($element->label) ? (' ' . $element->label) : '') . '">' .
-                        '<img src="' . $element->url . '" alt="' . htmlentities($element->alt) . '">' .
+                    ($link ? '<a href="' . $link . '"' . $targetCode . '>' . $img . '</a>' : $img) .
                     '</p>'
                 );
             case 'embed':


### PR DESCRIPTION
Improve performance on RichText::asHtml, there was an update on RichText::insertSpans (copied from https://github.com/prismicio-community/php-kit/blob/master/src/Prismic/Dom/RichText.php).

No need to update BlockGroup.php dependency.